### PR TITLE
fix: respect host parameter from config when running CLI

### DIFF
--- a/sniffly/cli.py
+++ b/sniffly/cli.py
@@ -28,9 +28,10 @@ def cli():
 
 @cli.command()
 @click.option("--port", type=int, help="Port to run server on")
+@click.option("--host", type=str, help="Host to bind server to")
 @click.option("--no-browser", is_flag=True, help="Don't open browser automatically")
 @click.option("--clear-cache", is_flag=True, help="Clear all caches before starting")
-def init(port, no_browser, clear_cache):
+def init(port, host, no_browser, clear_cache):
     """Start the analytics dashboard"""
     # Clear cache if requested
     if clear_cache:
@@ -55,6 +56,10 @@ def init(port, no_browser, clear_cache):
     # Use provided port or get from config
     if port is None:
         port = cfg.get("port")
+    
+    # Use provided host or get from config
+    if host is None:
+        host = cfg.get("host")
 
     # Determine if we should open browser
     auto_browser = cfg.get("auto_browser")
@@ -66,7 +71,7 @@ def init(port, no_browser, clear_cache):
     # Start server in background thread
     from .server import start_server_with_args
 
-    server_thread = threading.Thread(target=start_server_with_args, args=(port,), daemon=True)
+    server_thread = threading.Thread(target=start_server_with_args, args=(port, host), daemon=True)
     server_thread.start()
 
     # Wait for server to start
@@ -74,12 +79,12 @@ def init(port, no_browser, clear_cache):
 
     # Open browser
     if should_open_browser:
-        url = f"http://localhost:{port}"
+        url = f"http://{host}:{port}"
         # Delay browser opening slightly to ensure server is ready
         threading.Timer(0.5, lambda: webbrowser.open(url)).start()
         click.echo(f"✨ Sniffly dashboard opened at {url}")
     else:
-        click.echo(f"✨ Sniffly running at http://localhost:{port}")
+        click.echo(f"✨ Sniffly running at http://{host}:{port}")
 
     click.echo("Press Ctrl+C to stop the server")
 
@@ -188,6 +193,9 @@ Usage Examples:
   
   # Start on a different port
   sniffly init --port 8090
+  
+  # Start on a different host
+  sniffly init --host 0.0.0.0
   
   # Start without opening browser
   sniffly init --no-browser

--- a/sniffly/server.py
+++ b/sniffly/server.py
@@ -1193,11 +1193,11 @@ async def favicon():
     )
 
 
-def start_server_with_args(port=8081):
+def start_server_with_args(port=8081, host="localhost"):
     """Start the server with specified arguments"""
     import uvicorn
 
-    uvicorn.run(app, host="127.0.0.1", port=port)
+    uvicorn.run(app, host=host, port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add --host CLI option to allow overriding host from command line
- Update start_server_with_args() to accept and use host parameter
- Fix CLI to pass host from config or command line to server
- Update URL construction to use configured host instead of hardcoded localhost
- Add host examples to help text

Fixes issue where host config setting was ignored and server always bound to 127.0.0.1